### PR TITLE
Added CVD plots, fixes #2

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -4,6 +4,7 @@ authors = ["Evert Provoost <evert@eprovst.net>"]
 version = "0.1.0"
 
 [deps]
+ColorSchemes = "35d6a980-a343-548e-a6ea-1d62b119f2f4"
 ColorTypes = "3da002f7-5984-5a60-b8a6-cbb66c0b333f"
 MakieCore = "20f20a25-4f0e-4fdf-b5d1-57303727442b"
 

--- a/src/DomainColoring.jl
+++ b/src/DomainColoring.jl
@@ -12,14 +12,14 @@
 
 module DomainColoring
 
-using MakieCore, ColorTypes
+using MakieCore, ColorTypes, ColorSchemes
 
-export domaincolor, checkerplot
+export domaincolor, checkerplot, pdphaseplot, tphaseplot
 
 """
     DomainColoring.shadedplot(
         f :: "Complex -> Complex",
-        shader :: "(Complex; kwargs...) -> Color",
+        shader :: "(Matrix{Complex}; kwargs...) -> Image",
         axes = (-1, 1, -1, 1);
         pixels = (720, 720),
         kwargs...
@@ -31,7 +31,7 @@ Takes a complex function and a shader and produces a Makie image plot.
 
 - **`f`** is the complex function to plot.
 
-- **`shader`** is the shader function to compute pixel colors.
+- **`shader`** is the shader function to compute the image.
 
 - **`axes`** are the limits of the rectangle to plot, in the format
   `(minRe, maxRe, minIm, maxIm)`, if one or two numbers are provided
@@ -42,15 +42,12 @@ Takes a complex function and a shader and produces a Makie image plot.
 - **`pixels`** is the number of pixels to compute in, respectively, the
   real and imaginary axis, taking the same for both if only one number
   is provided.
-
-The remaining keyword arguments are passed to the `shader` function.
 """
 function shadedplot(
         f,
         shader,
         axes = (-1, 1, -1, 1);
         pixels = (720, 720),
-        kwargs...
     )
     length(axes) == 1 && (axes = (-axes, axes, -axes, axes))
     length(axes) == 2 && (axes = (-axes[1], axes[1], -axes[2], axes[2]))
@@ -58,8 +55,7 @@ function shadedplot(
 
     x = range(axes[1], axes[2], length=pixels[1])
     y = range(axes[3], axes[4], length=pixels[2])
-    image(x, y, @. shader(f(x + im*y'); kwargs...);
-          axis=(autolimitaspect=1,))
+    image(x, y, shader(@. f(x + im*y')); axis=(autolimitaspect=1,))
 end
 
 """
@@ -84,7 +80,7 @@ function labsweep(θ)
 end
 
 """
-    DomainColoring.domaincolorshader(
+    DomainColoring.domaincolorpixelshader(
         w :: Complex;
         abs = false,
         logabs = false,
@@ -96,21 +92,17 @@ Takes a complex value **`w`** and shades it as in a domain coloring.
 
 For documentation of the remaining arguments see [`domaincolor`](@ref).
 """
-function domaincolorshader(
+function domaincolorpixelshader(
         w;
         abs = false,
         logabs = false,
         grid = false,
-        all = false,
     )
-    all && (abs = true; grid = true)
-    logabs && (abs = true)
-
     # phase color
     c = labsweep(angle(w))
 
     # add magnitude if requested
-    if abs
+    if abs || logabs
         m = Base.abs(w)
         logabs && (m = log(m))
         c = Lab(c.l + 20mod(m, 1) - 10, c.a, c.b)
@@ -138,6 +130,10 @@ end
 
 Takes a complex function and produces it's domain coloring as a Makie
 image plot.
+
+Red corresponds to phase ``0``, yellow to ``\\frac{\\pi}{3}``, green
+to ``\\frac{2\\pi}{3}``, cyan to ``\\pi``, blue to
+``\\frac{4\\pi}{3}``, and magenta to ``\\frac{5\\pi}{3}``.
 
 # Arguments
 
@@ -173,45 +169,122 @@ function domaincolor(
         grid = false,
         all = false,
     )
-    shadedplot(f, domaincolorshader, axes; pixels,
-               abs, logabs, grid, all)
+
+    if all
+        abs = true
+        grid = true
+    end
+
+    shadedplot(f, W -> domaincolorpixelshader.(
+                    W; abs, logabs, grid
+                  ), axes; pixels)
 end
 
+"""
+    pdphaseplot(
+        f :: "Complex -> Complex",
+        axes = (-1, 1, -1, 1);
+        pixels = (720, 720),
+    )
+
+Takes a complex valued function and produces a phase plot as a Makie
+image plot using [ColorCET](https://colorcet.com)'s CBC1 cyclic color
+map for protanopic and deuteranopic viewers.
+
+Yellow corresponds to phase ``0``, white to ``\\frac{\\pi}{2}``, blue
+to ``\\pi``, and black to ``\\frac{3\\pi}{2}``.
+
+# Arguments
+
+- **`f`** is the complex function to plot.
+
+- **`axes`** are the limits of the rectangle to plot, in the format
+  `(minRe, maxRe, minIm, maxIm)`, if one or two numbers are provided
+  instead they are take symmetric along the real and imaginary axis.
+
+# Keyword Arguments
+
+- **`pixels`** is the number of pixels to compute in, respectively, the
+  real and imaginary axis, taking the same for both if only one number
+  is provided.
+"""
+function pdphaseplot(
+        f,
+        axes = (-1, 1, -1, 1);
+        pixels = (720, 720),
+    )
+    shader(W) = get(
+        ColorSchemes.cyclic_protanopic_deuteranopic_bwyk_16_96_c31_n256,
+        @. mod(-angle(W) / 2π + .5, 1)
+    )
+    shadedplot(f, shader, axes; pixels)
+end
 
 """
-    DomainColoring.checkerplotshader(
+    tphaseplot(
+        f :: "Complex -> Complex",
+        axes = (-1, 1, -1, 1);
+        pixels = (720, 720),
+    )
+
+Takes a complex valued function and produces a phase plot as a Makie
+image plot using [ColorCET](https://colorcet.com)'s CBTC1 cyclic color
+map for titranopic viewers.
+
+Red corresponds to phase ``0``, white to ``\\frac{\\pi}{2}``, cyan to
+``\\pi``, and black to ``\\frac{3\\pi}{2}``.
+
+# Arguments
+
+- **`f`** is the complex function to plot.
+
+- **`axes`** are the limits of the rectangle to plot, in the format
+  `(minRe, maxRe, minIm, maxIm)`, if one or two numbers are provided
+  instead they are take symmetric along the real and imaginary axis.
+
+# Keyword Arguments
+
+- **`pixels`** is the number of pixels to compute in, respectively, the
+  real and imaginary axis, taking the same for both if only one number
+  is provided.
+"""
+function tphaseplot(
+        f,
+        axes = (-1, 1, -1, 1);
+        pixels = (720, 720),
+    )
+    shader(W) = get(
+        ColorSchemes.cyclic_tritanopic_cwrk_40_100_c20_n256,
+        @. mod(-angle(W) / 2π + 0.5, 1)
+    )
+    shadedplot(f, shader, axes; pixels)
+end
+
+"""
+    DomainColoring.checkerplotpixelshader(
         w :: Complex;
         real = false,
         imag = false,
         angle = false,
         abs = false,
-        polar = false,
     )
 
 Takes a complex value **`w`** and shades it as in a checker plot.
 
 For documentation of the remaining arguments see [`checkerplot`](@ref).
 """
-function checkerplotshader(
+function checkerplotpixelshader(
         w;
         real = false,
         imag = false,
         angle = false,
         abs = false,
-        polar = false,
     )
-    # set defaults if no options given
-    if !(angle || abs || polar || real || imag)
-        real = true; imag = true
-    end
-    # polar checker plot
-    polar && (angle = true; abs = true)
-
     g = 1.0
-    angle && (g *= sin(16*Base.angle(w)))
-    abs   && (g *= sin(5π*log(Base.abs(w))))
     real  && (g *= sin(5π*Base.real(w)))
     imag  && (g *= sin(5π*Base.imag(w)))
+    angle && (g *= sin(16*Base.angle(w)))
+    abs   && (g *= sin(5π*log(Base.abs(w))))
 
     return Gray(0.9min(1, sign(g) + 1) + 0.08)
 end
@@ -223,6 +296,7 @@ end
         pixels = (720, 720),
         real = false,
         imag = false,
+        rect = false,
         angle = false,
         abs = false,
         polar = false,
@@ -244,14 +318,17 @@ Takes a complex function and produces a checker plot as a Makie image.
   real and imaginary axis, taking the same for both if only one number
   is provided.
 
-If none of the below options are set, the plot defaults to `real = true`
-and `imag = true`.
+If none of the below options are set, the plot defaults to `rect = true`.
 
 - **`real`** plots black and white stripes orthogonal to the real axis
   at a rate of 5 stripes per unit.
 
 - **`imag`** plots black and white stripes orthogonal to the imaginary
   axis at a rate of 5 stripes per unit.
+
+- **`rect`** is a shortcut for `real = true` and `imag = true`.
+
+- **`phase`** is a shortcut for `angle = true` and `abs = true`.
 
 - **`angle`** plots black and white stripes orthogonal to the phase
   angle at a rate of 32 stripes per full rotation.
@@ -267,12 +344,28 @@ function checkerplot(
         pixels = (720, 720),
         real = false,
         imag = false,
+        rect = false,
         angle = false,
         abs = false,
         polar = false,
     )
-    shadedplot(f, checkerplotshader, axes; pixels,
-               real, imag, angle, abs, polar)
+    # set defaults if no options given
+    if !(real || imag || rect || angle || abs || polar)
+        rect = true
+    end
+    # carthesian checker plot
+    if rect
+        real = true
+        imag = true
+    end
+    # polar checker plot
+    if polar
+        angle = true
+        abs = true
+    end
+    shadedplot(f, W -> checkerplotpixelshader.(
+                    W; real, imag, angle, abs
+                  ), axes; pixels)
 end
 
 end


### PR DESCRIPTION
Adds `pdphaseplot` and `tphaseplot` providing phaseplots respectively readable for those with red-green or blue-yellow color vision deficiency.